### PR TITLE
 - Clarifies decoding into array, otherwise depending on PHP version …

### DIFF
--- a/src/Hcaptcha.php
+++ b/src/Hcaptcha.php
@@ -43,7 +43,7 @@ class Hcaptcha
             ));
 
         $context = stream_context_create($options);
-        $result = json_decode(file_get_contents($this->api, false, $context));
+        $result = json_decode(file_get_contents($this->api, false, $context),true);
 
         return new  HcaptchaResponse($result);
     }

--- a/src/HcaptchaResponse.php
+++ b/src/HcaptchaResponse.php
@@ -13,7 +13,7 @@ class HcaptchaResponse
         if ($response === null) {
             $this->errors[] = 'json-parse-failure';
         } else {
-            $this->success = $response->success;
+            $this->success = $response['success'];
             $this->errors = $response['error-codes'];
             $this->raw = $response;
         }


### PR DESCRIPTION
…one might get 'Cannot use object of type stdClass as array Exception at /src/HcaptchaResponse.php - l.17'

 - Fix $response accessed as an array and an object. json_decode result is either an array or an object.